### PR TITLE
Timing bug fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,18 +192,19 @@
       });
     </script>
     <script>
-      //variables for each unit
+      // variables for each unit
+      // set initial values
       var a = 0;
       var b = 0;
       var c = 0;
       var d = 0;
       var e = 0;
 
+      //show initial unit values
+      showUpdate();
+
       //each second
       window.setInterval(function () {
-        //set each unit
-        showUpdate();
-
         //add something a little interesting. Each unit will compound.
         //A does nothing
         //B gives .5 A
@@ -215,6 +216,9 @@
         b = b + c * 0.25;
         c = c + d * 0.1;
         d = d + e * 0.05;
+
+        //set each unit
+        showUpdate();
       }, 1000);
 
       function showUpdate() {


### PR DESCRIPTION
There were instances of the numbers not really matching up to the reality of what units you had. for example you could buy a B when you only had 9 A's, because what was happening was the update to the screen happened at the _beginning_ of the iteration, so essentially the values showed on screen were the _last_ iterations values,

Simply changing the _iteration_ code to do the math, and then show the values fixed it. I also added the showUpdate() function right away as a one time call right after setting the initial values to 0, to avoid the first second of gameplay being A A, B B, C C, D D, E E. just something that felt wierd.